### PR TITLE
Bulk Media Preload Update

### DIFF
--- a/src/shared/components/BulkMediaDownload.tsx
+++ b/src/shared/components/BulkMediaDownload.tsx
@@ -21,6 +21,7 @@ export const BulkMediaDownload: React.FC<BulkMediaDownloadProps> = ({
         isDownloading,
         progress,
         startDownload,
+        cancelDownload,
         isDownloadComplete,
         clearCache,
         error
@@ -42,11 +43,10 @@ export const BulkMediaDownload: React.FC<BulkMediaDownloadProps> = ({
         <div className="bg-white rounded-lg shadow-lg border border-gray-200 p-6 max-w-md mx-auto">
             <div className="flex justify-between items-start mb-4">
                 <h3 className="text-lg font-semibold text-gray-800">Preload Media</h3>
-                {onClose && (
+                {onClose &&(
                     <button
-                        onClick={onClose}
+                        onClick={() => {cancelDownload(); onClose();}}
                         className="text-gray-500 hover:text-gray-700"
-                        disabled={isDownloading}
                     >
                         <X size={20}/>
                     </button>

--- a/src/shared/components/BulkMediaDownload.tsx
+++ b/src/shared/components/BulkMediaDownload.tsx
@@ -1,20 +1,18 @@
-import React from 'react';
-import {Download, CheckCircle, AlertCircle, X} from 'lucide-react';
+import React, { useEffect } from 'react';
+import { CheckCircle, AlertCircle, X} from 'lucide-react';
 import {useBulkMediaDownload} from '@shared/hooks/useBulkMediaDownload';
-import {GameVersion, Slide} from '@shared/types/game';
+import {GameVersion} from '@shared/types/game';
 import {UserType} from '@shared/constants/formOptions';
 
 interface BulkMediaDownloadProps {
-    slides: Slide[],
-    userType: UserType,
     gameVersion: GameVersion,
+    userType: UserType,
     onClose?: () => void,
 }
 
 export const BulkMediaDownload: React.FC<BulkMediaDownloadProps> = ({
-                                                                        slides,
-                                                                        userType,
                                                                         gameVersion,
+                                                                        userType,
                                                                         onClose,
                                                                     }) => {
     const {
@@ -22,16 +20,18 @@ export const BulkMediaDownload: React.FC<BulkMediaDownloadProps> = ({
         progress,
         startDownload,
         cancelDownload,
-        isDownloadComplete,
         clearCache,
         error
-    } = useBulkMediaDownload();
+    } = useBulkMediaDownload();    
 
-    const downloadComplete = isDownloadComplete(gameVersion, userType);
+    useEffect(() => {
+        startDownload(gameVersion, userType);
+    }, [])
+
     const progressPercent = progress ? Math.round((progress.downloaded / progress.total) * 100) : 0;
 
     const handleStartDownload = async (): Promise<void> => {
-        await startDownload(slides, userType, gameVersion);
+        await startDownload(gameVersion, userType);
     };
 
     const handleClearCache = async (): Promise<void> => {
@@ -53,7 +53,7 @@ export const BulkMediaDownload: React.FC<BulkMediaDownloadProps> = ({
                 )}
             </div>
 
-            {downloadComplete && !isDownloading && (
+            {progress?.isComplete && !isDownloading && (
                 <div className="mb-4 p-3 bg-green-50 rounded-lg border border-green-200">
                     <div className="flex items-center text-green-800">
                         <CheckCircle size={20} className="mr-2"/>
@@ -101,18 +101,7 @@ export const BulkMediaDownload: React.FC<BulkMediaDownloadProps> = ({
             )}
 
             <div className="space-y-3">
-                {!downloadComplete && !isDownloading && (
-                    <button
-                        onClick={handleStartDownload}
-                        className="w-full flex items-center justify-center px-4 py-2 bg-game-orange-500 hover:bg-game-orange-600 text-white rounded-lg font-medium transition-colors"
-                        disabled={isDownloading}
-                    >
-                        <Download size={18} className="mr-2"/>
-                        Preload All Media ({slides.filter(s => s.source_path).length} files)
-                    </button>
-                )}
-
-                {(downloadComplete || error) && (
+                {(error) || progress?.isComplete && (
                     <button
                         onClick={handleClearCache}
                         className="w-full px-4 py-2 bg-gray-500 hover:bg-gray-600 text-white rounded-lg font-medium transition-colors"
@@ -125,7 +114,7 @@ export const BulkMediaDownload: React.FC<BulkMediaDownloadProps> = ({
 
             <div className="mt-4 text-xs text-gray-500">
                 <p>This will preload all presentation media to your device for faster loading.</p>
-                {downloadComplete && (
+                {progress?.isComplete && (
                     <p className="mt-1 text-green-600">✓ Files cached locally - Playback is not dependent on internet speed</p>
                 )}
             </div>

--- a/src/shared/hooks/useBulkMediaDownload.ts
+++ b/src/shared/hooks/useBulkMediaDownload.ts
@@ -1,4 +1,4 @@
-import {useState, useCallback} from 'react';
+import {useState, useCallback } from 'react';
 import {mediaManager} from '@shared/services/MediaManager';
 import {GameVersion, Slide} from '@shared/types/game';
 import {UserType} from '@shared/constants/formOptions';
@@ -15,6 +15,7 @@ interface UseBulkMediaDownloadReturn {
     isDownloading: boolean;
     progress: BulkDownloadProgress | null;
     startDownload: (slides: Slide[], userType: UserType, gameVersion: GameVersion) => Promise<void>;
+    cancelDownload: () => void;
     isDownloadComplete: (gameVersion?: GameVersion, userType?: UserType) => boolean;
     clearCache: () => void;
     error: string | null;
@@ -31,6 +32,8 @@ export const useBulkMediaDownload = (): UseBulkMediaDownloadReturn => {
         userType: UserType,
         gameVersion?: GameVersion
     ): Promise<void> => {
+        
+        if (mediaManager.isBulkDownloadInProgress()) return;
         setIsDownloading(true);
         setError(null);
         setProgress(null);
@@ -58,6 +61,8 @@ export const useBulkMediaDownload = (): UseBulkMediaDownloadReturn => {
         return mediaManager.isBulkDownloadComplete(gameVersion, userType);
     }, [cacheCleared]); // ADD cacheCleared as dependency
 
+    const cancelDownload = useCallback((): void => mediaManager.cancelBulkDownload(), []);
+
     const clearCache = useCallback((): void => {
         mediaManager.clearBulkDownloadCache();
         setProgress(null);
@@ -69,6 +74,7 @@ export const useBulkMediaDownload = (): UseBulkMediaDownloadReturn => {
         isDownloading,
         progress,
         startDownload,
+        cancelDownload,
         isDownloadComplete,
         clearCache,
         error

--- a/src/shared/hooks/useSignedMediaUrl.ts
+++ b/src/shared/hooks/useSignedMediaUrl.ts
@@ -33,14 +33,20 @@ export const useSignedMediaUrl = (sourcePath: string | undefined, gameVersion?: 
             return;
         }
 
-        let isMounted: boolean = true;
+        let isMounted = true;
 
         const fetchUrl = async () => {
             setState({url: null, isLoading: true, error: null});
             try {
-                const signedUrl: string = await mediaManager.getSignedUrlWithFallback(sourcePath, userType, gameVersion);
+                // Use the new unified API
+                const blobUrl = await mediaManager.getMediaUrlWithFallback(
+                    sourcePath,
+                    userType,
+                    gameVersion
+                );
+                
                 if (isMounted) {
-                    setState({url: signedUrl, isLoading: false, error: null});
+                    setState({url: blobUrl, isLoading: false, error: null});
                 }
             } catch (err) {
                 if (isMounted) {
@@ -56,7 +62,7 @@ export const useSignedMediaUrl = (sourcePath: string | undefined, gameVersion?: 
         return () => {
             isMounted = false;
         };
-    }, [sourcePath, userType, gameVersion]); // Re-run when sourcePath OR userType changes.
+    }, [sourcePath, userType, gameVersion]);
 
     return state;
 };

--- a/src/shared/hooks/useSlidePreCaching.ts
+++ b/src/shared/hooks/useSlidePreCaching.ts
@@ -18,7 +18,7 @@ interface UseSlidePreCachingOptions {
  *
  * @param slides Array of all slides in the presentation
  * @param currentSlideIndex The current slide index
- * @param gameVersion Game version for 1.5 slide logic
+ * @param gameVersion Game version for version-specific slide logic
  * @param options Precaching configuration options
  */
 export const useSlidePreCaching = (

--- a/src/shared/services/IndexedDBCache.ts
+++ b/src/shared/services/IndexedDBCache.ts
@@ -168,6 +168,32 @@ class IndexedDBCache {
     }
 
     /**
+     * Get all keys (file names) stored in IndexedDB
+     * Useful for validation and cache management
+     */
+    public async getAllKeys(): Promise<string[]> {
+        await this.init();
+        if (!this.db) return [];
+
+        return new Promise((resolve, reject) => {
+            const transaction = this.db!.transaction([this.STORE_NAME], 'readonly');
+            const store = transaction.objectStore(this.STORE_NAME);
+            const request = store.getAllKeys();
+
+            request.onsuccess = () => {
+                const keys = request.result as string[];
+                console.log(`[IndexedDBCache] Retrieved ${keys.length} keys from IndexedDB`);
+                resolve(keys);
+            };
+
+            request.onerror = () => {
+                console.error('[IndexedDBCache] Failed to get all keys:', request.error);
+                reject(request.error);
+            };
+        });
+    }
+
+    /**
      * Clear all expired entries from IndexedDB
      */
     public async cleanupExpired(): Promise<void> {

--- a/src/shared/utils/video/useHostVideo.ts
+++ b/src/shared/utils/video/useHostVideo.ts
@@ -357,12 +357,6 @@ export const useHostVideo = ({sessionId, sourceUrl, isEnabled}: UseHostVideoProp
                         return;
                     }
 
-                    // Don't auto-play if video is not ready
-                    if (video.readyState < 2) {
-                        videoDebug.videoLog('useHostVideo', 'Video not ready, skipping auto-play');
-                        return;
-                    }
-
                     try {
                         // Auto-play logic using current state from ref
                         video.currentTime = 0; // Start from beginning

--- a/src/views/host/components/CreateGame/MediaDownloadStep.tsx
+++ b/src/views/host/components/CreateGame/MediaDownloadStep.tsx
@@ -24,36 +24,32 @@ const MediaDownloadStep: React.FC<MediaDownloadStepProps> = ({
         isDownloading,
         progress,
         startDownload,
+        cancelDownload,
         isDownloadComplete,
         clearCache,
         error
     } = useBulkMediaDownload();
 
     const downloadComplete = isDownloadComplete(gameData.game_version, userType);
-    const progressPercent = progress ? Math.round((progress.downloaded / progress.total) * 100) : 0;
+    const progressPercent = progress ?
+        Math.round((progress.downloaded / progress.total) * 100) : 0;
     const [userOptedOut, setUserOptedOut] = React.useState(false);
-    const hasAttemptedAutoStart = React.useRef(false);
 
     // Auto-start download on mount if not already complete and user hasn't opted out
     useEffect(() => {
-        // Only attempt once
-        if (hasAttemptedAutoStart.current) {
-            return;
-        }
-
         if (!downloadComplete && !isDownloading && !error && !userOptedOut) {
             console.log('[MediaDownloadStep] Auto-starting download...');
-            hasAttemptedAutoStart.current = true;
             startDownload(gameStructure.slides, userType, gameData.game_version);
         }
     }, [downloadComplete, isDownloading, error, userOptedOut, gameStructure.slides, userType, gameData.game_version, startDownload]);
 
     const handleSkipAndContinue = (): void => {
+        cancelDownload();
         setUserOptedOut(true);
         console.log('[MediaDownloadStep] User skipped download');
     };
 
-    const handleRetry = async (): Promise<void> => {
+    const handleStartDownloadAgain = async (): Promise<void> => {
         setUserOptedOut(false);
         await startDownload(gameStructure.slides, userType, gameData.game_version);
     };
@@ -129,7 +125,8 @@ const MediaDownloadStep: React.FC<MediaDownloadStepProps> = ({
                                 Loading Media Files
                             </h3>
                             <p className="text-sm text-blue-700 mb-3">
-                                Please wait while we preload all presentation content. This may take a minute...
+                                Please wait while we preload all presentation content.
+                                This may take a minute...
                             </p>
 
                             <div className="space-y-2">
@@ -160,17 +157,6 @@ const MediaDownloadStep: React.FC<MediaDownloadStepProps> = ({
                                     </p>
                                 )}
                             </div>
-
-                            {/* ADD: Continue Anyway button during download */}
-                            <div className="mt-4 pt-4 border-t border-blue-200">
-                                <button
-                                    onClick={handleSkipAndContinue}
-                                    className="text-sm text-blue-700 hover:text-blue-900 underline flex items-center gap-1"
-                                >
-                                    <ArrowRight size={14}/>
-                                    Continue anyway without waiting (not recommended)
-                                </button>
-                            </div>
                         </div>
                     </div>
                 </div>
@@ -189,7 +175,7 @@ const MediaDownloadStep: React.FC<MediaDownloadStepProps> = ({
                                 {error}
                             </p>
                             <button
-                                onClick={handleRetry}
+                                onClick={handleStartDownloadAgain}
                                 className="px-4 py-2 bg-red-600 hover:bg-red-700 text-white text-sm rounded-lg font-medium transition-colors"
                             >
                                 Try Again
@@ -213,36 +199,16 @@ const MediaDownloadStep: React.FC<MediaDownloadStepProps> = ({
                                 delays during your presentation.
                             </p>
                             <button
-                                onClick={handleRetry}
+                                onClick={handleStartDownloadAgain}
                                 className="text-sm text-yellow-700 underline hover:text-yellow-800 flex items-center gap-1"
                             >
                                 <Download size={14}/>
-                                Preload anyway
+                                Start preloading now
                             </button>
                         </div>
                     </div>
                 </div>
             )}
-
-            {/* Info Box - Only show if not downloaded and not downloading */}
-            {!downloadComplete && !isDownloading && !userOptedOut && !error && (
-                <div className="p-4 bg-gray-50 rounded-lg border border-gray-200">
-                    <h4 className="font-semibold text-gray-800 mb-2 text-sm flex items-center">
-                        <Info size={16} className="mr-2"/>
-                        Why preload content?
-                    </h4>
-                    <ul className="text-xs text-gray-700 space-y-1.5 list-disc list-inside">
-                        <li>Instant slide loading with no delays</li>
-                        <li>Smooth video playback without buffering</li>
-                        <li>Works even with poor internet connection</li>
-                        <li>Better presentation experience overall</li>
-                    </ul>
-                    <p className="text-xs text-blue-600 mt-3 font-medium">
-                        💡 Content is shared across all games using <strong>{gameVersionDisplayName}</strong>
-                    </p>
-                </div>
-            )}
-
             {/* Navigation Buttons */}
             <div className="flex justify-between items-center pt-4">
                 <button
@@ -255,7 +221,7 @@ const MediaDownloadStep: React.FC<MediaDownloadStepProps> = ({
                 </button>
 
                 <div className="flex gap-3">
-                    {!downloadComplete && !userOptedOut && !isDownloading && !error && (
+                    {!downloadComplete && !userOptedOut && !error && (
                         <button
                             type="button"
                             onClick={handleSkipAndContinue}

--- a/src/views/host/components/CreateGame/MediaDownloadStep.tsx
+++ b/src/views/host/components/CreateGame/MediaDownloadStep.tsx
@@ -25,23 +25,21 @@ const MediaDownloadStep: React.FC<MediaDownloadStepProps> = ({
         progress,
         startDownload,
         cancelDownload,
-        isDownloadComplete,
         clearCache,
         error
     } = useBulkMediaDownload();
 
-    const downloadComplete = isDownloadComplete(gameData.game_version, userType);
     const progressPercent = progress ?
         Math.round((progress.downloaded / progress.total) * 100) : 0;
     const [userOptedOut, setUserOptedOut] = React.useState(false);
 
     // Auto-start download on mount if not already complete and user hasn't opted out
     useEffect(() => {
-        if (!downloadComplete && !isDownloading && !error && !userOptedOut) {
+        if (!progress?.isComplete && !isDownloading && !error && !userOptedOut) {
             console.log('[MediaDownloadStep] Auto-starting download...');
-            startDownload(gameStructure.slides, userType, gameData.game_version);
+            startDownload(gameData.game_version, userType, );
         }
-    }, [downloadComplete, isDownloading, error, userOptedOut, gameStructure.slides, userType, gameData.game_version, startDownload]);
+    }, [isDownloading, error, userOptedOut, gameStructure.slides, userType, gameData.game_version, startDownload]);
 
     const handleSkipAndContinue = (): void => {
         cancelDownload();
@@ -51,16 +49,16 @@ const MediaDownloadStep: React.FC<MediaDownloadStepProps> = ({
 
     const handleStartDownloadAgain = async (): Promise<void> => {
         setUserOptedOut(false);
-        await startDownload(gameStructure.slides, userType, gameData.game_version);
+        await startDownload(gameData.game_version, userType);
     };
 
     const handleClearAndRedownload = async (): Promise<void> => {
         clearCache();
         setUserOptedOut(false);
-        await startDownload(gameStructure.slides, userType, gameData.game_version);
+        await startDownload(gameData.game_version, userType);
     };
 
-    const canProceed = downloadComplete || userOptedOut || error;
+    const canProceed = progress?.isComplete || userOptedOut || error;
 
     return (
         <div className="space-y-6">
@@ -92,7 +90,7 @@ const MediaDownloadStep: React.FC<MediaDownloadStepProps> = ({
             </div>
 
             {/* Already Downloaded Status */}
-            {downloadComplete && !isDownloading && (
+            {progress?.isComplete && !isDownloading && (
                 <div className="p-4 bg-green-50 rounded-lg border border-green-200">
                     <div className="flex items-start">
                         <CheckCircle size={24} className="text-green-600 mr-3 flex-shrink-0 mt-0.5"/>
@@ -186,7 +184,7 @@ const MediaDownloadStep: React.FC<MediaDownloadStepProps> = ({
             )}
 
             {/* Skipped Status */}
-            {userOptedOut && !downloadComplete && !isDownloading && (
+            {userOptedOut && !isDownloading && (
                 <div className="p-4 bg-yellow-50 rounded-lg border border-yellow-200">
                     <div className="flex items-start">
                         <AlertCircle size={24} className="text-yellow-600 mr-3 flex-shrink-0 mt-0.5"/>
@@ -221,7 +219,7 @@ const MediaDownloadStep: React.FC<MediaDownloadStepProps> = ({
                 </button>
 
                 <div className="flex gap-3">
-                    {!downloadComplete && !userOptedOut && !error && (
+                    {!progress?.isComplete && !userOptedOut && !error && (
                         <button
                             type="button"
                             onClick={handleSkipAndContinue}

--- a/src/views/host/components/GameControls.tsx
+++ b/src/views/host/components/GameControls.tsx
@@ -128,9 +128,8 @@ const GameControls: React.FC<GameControlsProps> = ({joinInfo, setJoinInfo, isJoi
             {showBulkDownload && state.gameStructure && (
                 <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
                     <BulkMediaDownload
-                        slides={state.gameStructure.slides}
-                        userType={getUserType(user)}
                         gameVersion={gameVersion}
+                        userType={getUserType(user)}
                         onClose={() => setShowBulkDownload(false)}
                     />
                 </div>

--- a/src/views/host/pages/GameResultsPage.tsx
+++ b/src/views/host/pages/GameResultsPage.tsx
@@ -271,7 +271,7 @@ const GameResultsPage: React.FC = () => {
                                                 </span>
                                         </div>
                                     </td>
-                                    <td className="px-6 py-4">
+                                    <td className="px-6 py-4 text-center">
                                             <span
                                                 className={`font-medium ${index === 0 ? 'text-yellow-600' : 'text-gray-900'}`}>
                                                 {team.team.name}


### PR DESCRIPTION
Updated Media manager:
- Made all files cache to indexDB when fetched
- Most recently fetched files will be in memory cache
- Added ability to cancel bulk preload
- Fixed UI bugs with bulk preload 
- Fixed retrieval bug, logic now checks memory, indexdb, then supabase for files.